### PR TITLE
Feature/switching views for iteration1

### DIFF
--- a/src/Cover.js
+++ b/src/Cover.js
@@ -7,3 +7,10 @@ class Cover {
     this.tagline2 = descriptor2;
   }
 }
+
+
+
+// 1. listen event is triggered
+// 2. function is called
+// 3. random integer from function is used to select from that index of the arrays such as cover, descriptor etc.
+// 4. use object created with cover class and random integer to replace variables using inner html 

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+// This is a test.
 // Create variables targetting the relevant DOM elements here 👇
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,23 @@
-// This is a test.
+// This is another test.
 // Create variables targetting the relevant DOM elements here 👇
-
+var randomCoverButton = document.querySelector('.random-cover-button');
+var coverTitle = document.querySelector('.cover-title');
+var imageCover = document.querySelector('.cover-image');
+var tagline1 = document.querySelector('.tagline-1');
+var tagline2 = document.querySelector('.tagline-2');
 
 // We've provided a few variables below
 var savedCovers = [
   new Cover("http://3.bp.blogspot.com/-iE4p9grvfpQ/VSfZT0vH2UI/AAAAAAAANq8/wwQZssi-V5g/s1600/Do%2BNot%2BForsake%2BMe%2B-%2BImage.jpg", "Sunsets and Sorrows", "sunsets", "sorrows")
 ];
-var currentCover;
+// var currentCover;
+imageCover.src = covers[getRandomIndex(covers)];
+coverTitle.innerText = titles[getRandomIndex(titles)];
+tagline1.innerText = descriptors[getRandomIndex(descriptors)];
+tagline2.innerText = descriptors[getRandomIndex(descriptors)];
 
 // Add your event listeners here 👇
-
+randomCoverButton.addEventListener("click", getRandomCover)
 
 // Create your event handlers and other functions here 👇
 
@@ -17,4 +25,12 @@ var currentCover;
 // We've provided one function to get you started
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
+}
+
+function getRandomCover() {
+  imageCover.src = covers[getRandomIndex(covers)];
+  coverTitle.innerText = titles[getRandomIndex(titles)];
+  tagline1.innerText = descriptors[getRandomIndex(descriptors)];
+  tagline2.innerText = descriptors[getRandomIndex(descriptors)];
+ // currentCover = new Cover(imageCover, coverTitle, tagline1, tagline2)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,28 +1,38 @@
-// This is another test.
 // Create variables targetting the relevant DOM elements here 👇
+
+//The variables for iteration 0
 var randomCoverButton = document.querySelector('.random-cover-button');
 var coverTitle = document.querySelector('.cover-title');
 var imageCover = document.querySelector('.cover-image');
 var tagline1 = document.querySelector('.tagline-1');
 var tagline2 = document.querySelector('.tagline-2');
+var makeNewButton = document.querySelector('.make-new-button');
+
+//The variables for iteration 1
+var homeButton = document.querySelector('.home-button');
+var form = document.querySelector('.form-view');
+var homeSection = document.querySelector('.home-view');
+var saveButton = document.querySelector('.save-cover-button');
+var viewSavedCoversButton = document.querySelector('.view-saved-button')
+var savedCoversSection = document.querySelector('.saved-view');
 
 // We've provided a few variables below
 var savedCovers = [
   new Cover("http://3.bp.blogspot.com/-iE4p9grvfpQ/VSfZT0vH2UI/AAAAAAAANq8/wwQZssi-V5g/s1600/Do%2BNot%2BForsake%2BMe%2B-%2BImage.jpg", "Sunsets and Sorrows", "sunsets", "sorrows")
 ];
-// var currentCover;
+var currentCover;
 imageCover.src = covers[getRandomIndex(covers)];
 coverTitle.innerText = titles[getRandomIndex(titles)];
 tagline1.innerText = descriptors[getRandomIndex(descriptors)];
 tagline2.innerText = descriptors[getRandomIndex(descriptors)];
 
 // Add your event listeners here 👇
-randomCoverButton.addEventListener("click", getRandomCover)
+randomCoverButton.addEventListener('click', getRandomCover);
+makeNewButton.addEventListener('click', switchToMakeYourOwnCover);
+viewSavedCoversButton.addEventListener('click', switchToSavedCovers);
+homeButton.addEventListener('click', returnToHome);
 
 // Create your event handlers and other functions here 👇
-
-
-// We've provided one function to get you started
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
 }
@@ -32,5 +42,28 @@ function getRandomCover() {
   coverTitle.innerText = titles[getRandomIndex(titles)];
   tagline1.innerText = descriptors[getRandomIndex(descriptors)];
   tagline2.innerText = descriptors[getRandomIndex(descriptors)];
- // currentCover = new Cover(imageCover, coverTitle, tagline1, tagline2)
+  currentCover = new Cover(imageCover, coverTitle, tagline1, tagline2);
+}
+
+function switchToMakeYourOwnCover() {
+  form.classList.remove('hidden');
+  homeButton.classList.remove('hidden');
+  homeSection.classList.add('hidden');
+  randomCoverButton.classList.add('hidden');
+  saveButton.classList.add('hidden');
+}
+
+function switchToSavedCovers() {
+  savedCoversSection.classList.remove('hidden');
+  homeButton.classList.remove('hidden');
+  homeSection.classList.add('hidden');
+  randomCoverButton.classList.add('hidden'); 
+  saveButton.classList.add('hidden'); 
+}
+
+function returnToHome() {
+  homeSection.classList.remove('hidden');
+  randomCoverButton.classList.remove('hidden'); 
+  saveButton.classList.remove('hidden'); 
+  homeButton.classList.add('hidden');
 }


### PR DESCRIPTION
**Form view:**
- When a user clicks the “Make Your Own Cover” button, we should see the form, and the homepage view should be hidden
- When the Form view is visible, the “Show New Random Cover” and “Save Cover” buttons should be hidden
- When the Form view is visible, the “Home” button should be visible

**Saved covers view:**
- When a user clicks the “View Saved Covers” button, we should see the saved covers section, and the homepage view should be hidden
- When the Saved Covers view is visible, the “Show New Random Cover” and “Save Cover” buttons should be hidden
- When the Saved Covers view is visible, the “Home” button should be visible

**For both the Make New Cover form section and the Saved Covers section:**
- In summary: Be able to switch between the three views (main poster, form, and saved posters) on the correct button clicks
- When a user clicks the “Home” button, we should only see the Home section
- When a user clicks the “Home” button, the home button should be hidden
- When a user clicks the “Home” button, the “Show New Random Cover” and “Save Cover” buttons should be visible again